### PR TITLE
add ticket names. fix high security warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -574,9 +574,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "logform": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^7.0.0",
     "express": "^4.16.4",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "node-fetch": "^2.3.0",
     "request": "^2.88.0",
     "winston": "^3.2.1"

--- a/src/core/slack.js
+++ b/src/core/slack.js
@@ -69,6 +69,18 @@ const whatColor = ticketType => {
     case "THAT Counselor Bundle":
       color = colors.speaker;
       break;
+    case "Camper":
+      color = colors.camper;
+      break;
+    case "Patron Camper":
+      color = colors.camper;
+      break;
+    case "Partner":
+      color = colors.sponsor;
+      break;
+    case "Corporate Partner":
+      color = colors.sponsor;
+      break
   }
 
   return color;


### PR DESCRIPTION
Update for wi/2020

the new event for .env is `that-conference-2020`